### PR TITLE
Bump spring.version from 3.1.2.RELEASE to 5.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,6 @@
   
   <properties>
   	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  	<spring.version>3.1.2.RELEASE</spring.version>
+  	<spring.version>5.3.6</spring.version>
   </properties>
 </project>


### PR DESCRIPTION
Bumps `spring.version` from 3.1.2.RELEASE to 5.3.6.

Updates `spring-webmvc` from 3.1.2.RELEASE to 5.3.6
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.1.2.RELEASE...v5.3.6)

Updates `spring-jdbc` from 3.1.2.RELEASE to 5.3.6
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.1.2.RELEASE...v5.3.6)

Updates `spring-context` from 3.1.2.RELEASE to 5.3.6
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.1.2.RELEASE...v5.3.6)

Updates `spring-aop` from 3.1.2.RELEASE to 5.3.6
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.1.2.RELEASE...v5.3.6)

Updates `spring-core` from 3.1.2.RELEASE to 5.3.6
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.1.2.RELEASE...v5.3.6)

Updates `spring-test` from 3.1.2.RELEASE to 5.3.6
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.1.2.RELEASE...v5.3.6)

Signed-off-by: dependabot[bot] <support@github.com>